### PR TITLE
Fix empty CTCP ACTION sending two literal underscores on Discord

### DIFF
--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -257,10 +257,14 @@ func (i *ircListener) OnPrivateMessage(e *irc.Event) {
 		replacements...,
 	).Replace(e.Message())
 
-	if e.Code == "CTCP_ACTION" {
+
+	// Italicize the /me action so it appears like Discord's /me functionality.
+	// We don't do it for empty messages, since Discord will show two literal underscores.
+	// Sending empty messages onto the discordMessagesChan is fine, since the sender will
+	// take care of inserting ZWBs if necessary. 
+	if e.Code == "CTCP_ACTION" && msg != "" {
 		msg = "_" + msg + "_"
 	}
-
 	msg = ircf.BlocksToMarkdown(ircf.Parse(msg))
 
 	go func(e *irc.Event) {


### PR DESCRIPTION
## The Bug that this PR Fixes

Sending an empty CTCP ACTION (i.e. a /me command) from IRC will make `go-discord-irc` send the message `__` (two underscores) to Discord. This renders on Discord clients as literal underscores instead of an empty message, breaking the expectation of the IRC user and changing the perceived content of the message.

Having any non-zero whitespace in the CTCP ACTION will not cause this issue (only the true empty string), as Discord renders the sequence `_ _` as empty but `__` as two literal underscores.

This issue is rather obscure since most IRC clients forbid you from sending an empty CTCP ACTION. However, with the use of programmatic bots/clients, you can do this. (It is common when you want to play with the bot's nickname). The intended look of these messages is that it shows the nick of the user in emphasis, without a message to follow it. So, it is a bug in `go-discord-irc` that there is a visible message content.

## The Implemented Fix

The wrapping of IRC CTCP ACTION commands with underscores to mimic the italicization on Discord happens before the logic for ZWB treatment of empty messages. This means that we wrap the empty CTCP ACTION with underscore characters, before sending it onto the Go channel read by `bridge.go`, which then sees a non-empty message and thus does not insert ZWBs.

This commit fixes the bug by not wrapping a CTCP ACTION with underscores if the content is empty. This way, an empty message is sent onto the Go channel ready by `bridge.go`, which then will give the necessary ZWB treatment, and send an empty message onto Discord.